### PR TITLE
Epochs and Video

### DIFF
--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -50,7 +50,7 @@ def session_to_nwb(
     hd = nwb.io.get_matlab_hd(mat_path / 'TrackingProcessed.mat', vbl_name='ang')
     epochs = pd.read_csv(mat_path / 'Epoch_TS.csv', header=None, names=['Start', 'End'])
     spikes, waveforms, shank_id = nwb.io.get_matlab_spikes(mat_path)
-    events = nwb.io.get_openephys_events(dataset_path / folder_name / 'Analysis' / 'states.npy', dataset_path / folder_name / 'Analysis' / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
+    events = nwb.io.get_openephys_events(mat_path / 'states.npy', mat_path / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
 
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -14,6 +14,7 @@ def session_to_nwb(
     mat_path: Path,
     sleep_path: Path,
     video_file_paths: list[Path],
+    timestamps_file_paths: list[Path],
     save_path: Path
 ):
     """Convert a session to NWB format.
@@ -78,7 +79,7 @@ def session_to_nwb(
             },
         }
     }
-    nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, metadata=metadata, rate=40.0)
+    nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, timestamp_file_paths=timestamps_file_paths, metadata=metadata)
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)
@@ -103,6 +104,11 @@ def main():
         dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording2" / "BonsaiVideo2025-06-18T15_36_52.avi",
         dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording3" / "BonsaiVideo2025-06-18T17_10_04.avi",
     ]
+    timestamps_file_paths = [
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording1" / "BonsaiTracking2025-06-18T15_23_48.csv",
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording2" / "BonsaiTracking2025-06-18T15_36_51.csv",
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording3" / "BonsaiTracking2025-06-18T17_10_02.csv",
+    ]
     save_path = output_folder_path
 
     session_to_nwb(
@@ -114,6 +120,7 @@ def main():
         mat_path=mat_path,
         sleep_path=sleep_path,
         video_file_paths=video_file_paths,
+        timestamps_file_paths=timestamps_file_paths,
         save_path=save_path
     )
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -54,18 +54,12 @@ def session_to_nwb(
 
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    
-    # add probes
-    nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data)
-    # add tracking
-    nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
-    # add spikes
-    nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
-    # Add event times
-    nwbfile = nwb.convert.add_events(nwbfile, events)
-    # Add epochs
-    nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
-    # Add sleep scoring and pseudo EMG
-    nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name)
+    # nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data)
+    # nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
+    # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
+    # nwbfile = nwb.convert.add_events(nwbfile, events)
+    # nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
+    # nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name)
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)
@@ -74,7 +68,7 @@ def session_to_nwb(
 def main():
     """Define paths and convert example sessions to NWB."""
     dataset_path = Path('/Volumes/T7/CatalystNeuro/Dudchenko/NWB_Conversion')
-    output_folder_path = Path('/Volumes/T7/CatalystNeuro/Dudchenko/conversion_nwb')
+    output_folder_path = Path('/Volumes/T7/CatalystNeuro/Spyglass/raw')
     if output_folder_path.exists():
         shutil.rmtree(output_folder_path)
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -13,6 +13,7 @@ def session_to_nwb(
     meta_path: Path,
     mat_path: Path,
     sleep_path: Path,
+    video_file_path: Path,
     save_path: Path
 ):
     """Convert a session to NWB format.
@@ -61,6 +62,25 @@ def session_to_nwb(
     # nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
     # nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name)
 
+    metadata = {
+        'Video': {
+            'ImageSeries': {
+                'name': 'Video',
+                'description': 'Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
+                'source': str(video_file_path)
+            },
+            'CameraDevice': {
+                'name': 'camera_device 0', # This MUST be formatted exactly "camera_device {camera_id}" to be compatible with spyglass
+                'meters_per_pixel': 0.0016, # TODO: update this value
+                'manufacturer': 'Logitech',
+                'model': 'C930e',
+                'lens': 'built-in',
+                'camera_name': 'Video Camera',
+            },
+        }
+    }
+    nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_path=video_file_path, metadata=metadata, rate=40.0)
+
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)
 
@@ -79,6 +99,7 @@ def main():
     meta_path = dataset_path / 'CatalystNeuro_metadata.xlsx'  # path to metadata file
     mat_path = dataset_path / folder_name / "Processed" / 'Analysis'
     sleep_path = dataset_path / folder_name / "Processed" / 'Sleep'
+    video_file_path = dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording1" / "BonsaiVideo2025-06-18T15_23_50.avi"
     save_path = output_folder_path
 
     session_to_nwb(
@@ -89,6 +110,7 @@ def main():
         meta_path=meta_path,
         mat_path=mat_path,
         sleep_path=sleep_path,
+        video_file_path=video_file_path,
         save_path=save_path
     )
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -43,14 +43,14 @@ def session_to_nwb(
     xml_data = nwb.io.read_xml(xml_path)  # load all ephys info from the xml file
     nrs_data = nwb.io.read_nrs(nrs_path)  # load faulty channel info from the nrs file (i.e. channels not shown in Neuroscope)
     metadata = nwb.io.read_metadata(meta_path, folder_name, print_output=True)  # Load all metadata from the xlsx file
-    start_time = nwb.io.get_start_time(dataset_path, folder_name)  # load start time from Metadata.txt file
+    start_time = nwb.io.get_start_time(folder_name, dataset_path / folder_name / 'Analysis' / 'Metadata.txt')  # load start time from Metadata.txt file
 
     # Load tracking, epochs and spikes from Matlab files (mostly loaded as pynapple objects)
     pos = nwb.io.get_matlab_position(mat_path / 'TrackingProcessed.mat', vbl_name='pos')
     hd = nwb.io.get_matlab_hd(mat_path / 'TrackingProcessed.mat', vbl_name='ang')
     epochs = pd.read_csv(mat_path / 'Epoch_TS.csv', header=None, names=['Start', 'End'])
     spikes, waveforms, shank_id = nwb.io.get_matlab_spikes(mat_path)
-    events = nwb.io.get_openephys_events(dataset_path, folder_name, time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
+    events = nwb.io.get_openephys_events(dataset_path / folder_name / 'Analysis' / 'states.npy', dataset_path / folder_name / 'Analysis' / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
 
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -60,6 +60,20 @@ def session_to_nwb(
     # nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
     # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
     # nwbfile = nwb.convert.add_events(nwbfile, events)
+    metadata["task"] = {
+        'wake': {
+            'description': 'The rat was awake and foraging for scattered cereal in a cylindrical open field. The recording environment consisted of a cylindrical arena of 73 cm diameter, with 54 cm tall walls, painted light blue. A prominent visual cue was positioned at the top of the wall on the north side; this was 31.5 cm wide and 26 cm tall and consisted of two black horizontal stripes with a white stripe between them.',
+            'environment': 'cylindrical_open_field',
+        },
+        'sleep': {
+            'description': 'The rat was given a 90-minute sleep opportunity in a container placed inside the recording arena, during which recordings continued.',
+            'environment': 'sleep_container',
+        },
+        'wake_cue_rot': {
+            'description': 'The rat was awake and foraging for scattered cereal in a cylindrical open field. The recording environment consisted of a cylindrical arena of 73 cm diameter, with 54 cm tall walls, painted light blue. A prominent visual cue was positioned at the top of the wall on the north side; this was 31.5 cm wide and 26 cm tall and consisted of two black horizontal stripes with a white stripe between them.',
+            'environment': 'cylindrical_open_field',
+        },
+    }
     nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
     # nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name)
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -79,10 +79,20 @@ def session_to_nwb(
 
     metadata = {
         'Video': {
-            'ImageSeries': {
-                'name': 'Video',
-                'description': 'Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
-            },
+            'ImageSeries': [
+                {
+                    'name': 'Video1',
+                    'description': 'Video during epoch 1. Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
+                },
+                {
+                    'name': 'Video2',
+                    'description': 'Video during epoch 2. Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
+                },
+                {
+                    'name': 'Video3',
+                    'description': 'Video during epoch 3. Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
+                },
+            ],
             'CameraDevice': {
                 'name': 'camera_device 0', # This MUST be formatted exactly "camera_device {camera_id}" to be compatible with spyglass
                 'meters_per_pixel': 0.0016, # TODO: update this value

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -95,6 +95,8 @@ def session_to_nwb(
     }
     nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, timestamp_file_paths=timestamps_file_paths, metadata=metadata)
 
+    behavior_module = nwbfile.create_processing_module(name="behavior", description="behavior module")
+
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -13,7 +13,7 @@ def session_to_nwb(
     meta_path: Path,
     mat_path: Path,
     sleep_path: Path,
-    video_file_path: Path,
+    video_file_paths: list[Path],
     save_path: Path
 ):
     """Convert a session to NWB format.
@@ -67,7 +67,6 @@ def session_to_nwb(
             'ImageSeries': {
                 'name': 'Video',
                 'description': 'Video capturing and marker tracking were performed using Bonsai software 51 at 40 Hz. For the juvenile recordings, images were acquired through a Logitech C930e camera. To synchronise the images with the electrophysiology data, an Arduino microcontroller was programmed to send a random sequence of pulses to both the OpenEphys system and a LED light within the frame of the camera. The times when the LED light shone were detected by Bonsai and synchronisation of the pulses in the light and the electrophysiology data was done offline. For the adult recordings, images were acquired through an acA1300-75gc Basler camera with a LMVZ4411 Kowa lens, positioned at the ceiling of the rig. This camera was connected to the OpenEphys board, sending a pulse for each frame taken, allowing the synchronisation of the two streams of information.',
-                'source': str(video_file_path)
             },
             'CameraDevice': {
                 'name': 'camera_device 0', # This MUST be formatted exactly "camera_device {camera_id}" to be compatible with spyglass
@@ -79,7 +78,7 @@ def session_to_nwb(
             },
         }
     }
-    nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_path=video_file_path, metadata=metadata, rate=40.0)
+    nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, metadata=metadata, rate=40.0)
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)
@@ -99,7 +98,11 @@ def main():
     meta_path = dataset_path / 'CatalystNeuro_metadata.xlsx'  # path to metadata file
     mat_path = dataset_path / folder_name / "Processed" / 'Analysis'
     sleep_path = dataset_path / folder_name / "Processed" / 'Sleep'
-    video_file_path = dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording1" / "BonsaiVideo2025-06-18T15_23_50.avi"
+    video_file_paths = [
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording1" / "BonsaiVideo2025-06-18T15_23_50.avi",
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording2" / "BonsaiVideo2025-06-18T15_36_52.avi",
+        dataset_path / folder_name / "Raw" / "2025-06-18_15-23-44" / "Record Node 101" / "experiment1" / "recording3" / "BonsaiVideo2025-06-18T17_10_04.avi",
+    ]
     save_path = output_folder_path
 
     session_to_nwb(
@@ -110,7 +113,7 @@ def main():
         meta_path=meta_path,
         mat_path=mat_path,
         sleep_path=sleep_path,
-        video_file_path=video_file_path,
+        video_file_paths=video_file_paths,
         save_path=save_path
     )
 

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -60,7 +60,7 @@ def session_to_nwb(
     # nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
     # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
     # nwbfile = nwb.convert.add_events(nwbfile, events)
-    # nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
+    nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
     # nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name)
 
     metadata = {

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -67,18 +67,18 @@ def session_to_nwb(
 
 def main():
     """Define paths and convert example sessions to NWB."""
-    dataset_path = Path('/Volumes/T7/CatalystNeuro/Dudchenko/NWB_Conversion')
+    dataset_path = Path('/Volumes/T7/CatalystNeuro/Dudchenko')
     output_folder_path = Path('/Volumes/T7/CatalystNeuro/Spyglass/raw')
     if output_folder_path.exists():
         shutil.rmtree(output_folder_path)
 
     # Example session
     folder_name = 'H7115-250618'
-    xml_path = dataset_path / folder_name / (folder_name + '.xml')  # path to xml file
-    nrs_path = dataset_path / folder_name / (folder_name + '.nrs')  # path to xml file
+    xml_path = dataset_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
+    nrs_path = dataset_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
     meta_path = dataset_path / 'CatalystNeuro_metadata.xlsx'  # path to metadata file
-    mat_path = dataset_path / folder_name / 'Analysis'
-    sleep_path = dataset_path / folder_name / 'Sleep'
+    mat_path = dataset_path / folder_name / "Processed" / 'Analysis'
+    sleep_path = dataset_path / folder_name / "Processed" / 'Sleep'
     save_path = output_folder_path
 
     session_to_nwb(

--- a/conversion_scripts/nwb_h7100.py
+++ b/conversion_scripts/nwb_h7100.py
@@ -17,14 +17,14 @@ def main():
     xml_data = nwb.io.read_xml(xml_path)  # load all ephys info from the xml file
     nrs_data = nwb.io.read_nrs(nrs_path)  # load faulty channel info from the nrs file (i.e. channels not shown in Neuroscope)
     metadata = nwb.io.read_metadata(meta_path, folder_name, print_output=True)  # Load all metadata from the xlsx file
-    start_time = nwb.io.get_start_time(dataset_path, folder_name)  # load start time from Metadata.txt file
+    start_time = nwb.io.get_start_time(folder_name, dataset_path / folder_name / 'Analysis' / 'Metadata.txt')  # load start time from Metadata.txt file
 
     # Load tracking, epochs and spikes from Matlab files (mostly loaded as pynapple objects)
     pos = nwb.io.get_matlab_position(mat_path / 'TrackingProcessed.mat', vbl_name='pos')
     hd = nwb.io.get_matlab_hd(mat_path / 'TrackingProcessed.mat', vbl_name='ang')
     epochs = pd.read_csv(mat_path / 'Epoch_TS.csv', header=None, names=['Start', 'End'])
     spikes, waveforms, shank_id = nwb.io.get_matlab_spikes(mat_path)
-    events = nwb.io.get_openephys_events(dataset_path, folder_name, time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
+    events = nwb.io.get_openephys_events(dataset_path / folder_name / 'Analysis' / 'states.npy', dataset_path / folder_name / 'Analysis' / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
 
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "fmatch>=0.0.9",
     "jupyter>=1.1.1"
     "ndx-franklab-novela",
+    "opencv-python",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "seaborn>=0.11.0",
     "fmatch>=0.0.9",
     "jupyter>=1.1.1"
+    "ndx-franklab-novela",
 ]
 
 [project.urls]

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -10,7 +10,7 @@ import datajoint as dj
 from pathlib import Path
 import sys
 
-dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/spyglass/dj_local_conf.json"
+dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/Spyglass/spyglass/dj_local_conf.json"
 dj.config.load(dj_local_conf_path)  # load config for database connection info
 
 # General Spyglass Imports

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -66,6 +66,7 @@ def main():
     nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
 
     (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()
+    sgc.Task.delete()
 
     insert_session(nwbfile_path, rollback_on_fail=True, raise_err=True)
     print_tables(nwbfile_path=nwbfile_path)

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -48,6 +48,11 @@ def print_tables(nwbfile_path: Path):
         print("=== Subject ===", file=f)
         print(sgc.Subject(), file=f)
 
+        print("=== Camera Device ===", file=f)
+        print(sgc.CameraDevice & {"camera_name": "my_camera_name"}, file=f)
+        print("=== Video File ===", file=f)
+        print(sgc.VideoFile & {"camera_name": "my_camera_name"}, file=f)
+
 
 def main():
     nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/H7115-250618.nwb")

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -1,0 +1,64 @@
+"""SpyGlass database insertion script for the example dataset.
+
+This module provides functions for inserting converted NWB files from the example dataset into a SpyGlass database. 
+It handles data ingestion, custom table population, and validation testing for the database integration pipeline.
+"""
+
+from pynwb import NWBHDF5IO
+import numpy as np
+import datajoint as dj
+from pathlib import Path
+import sys
+
+dj_local_conf_path = "/Users/pauladkisson/Documents/CatalystNeuro/JadhavConv/spyglass/dj_local_conf.json"
+dj.config.load(dj_local_conf_path)  # load config for database connection info
+
+# General Spyglass Imports
+import spyglass.common as sgc  # this import connects to the database
+import spyglass.data_import as sgi
+from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
+
+
+def insert_session(nwbfile_path: Path, rollback_on_fail: bool = True, raise_err: bool = False):
+    """Insert complete session data from NWB file into SpyGlass database.
+
+    Performs comprehensive insertion of all session data including standard
+    SpyGlass tables and custom task-specific tables. This is the main entry
+    point for database ingestion of converted NWB files.
+
+    Parameters
+    ----------
+    nwbfile_path : Path
+        Path to the converted NWB file to insert into the database.
+    rollback_on_fail : bool, optional
+        Whether to rollback database transaction if insertion fails, by default True.
+    raise_err : bool, optional
+        Whether to raise exceptions on insertion errors, by default False.
+    """
+    sgi.insert_sessions(str(nwbfile_path), rollback_on_fail=rollback_on_fail, raise_err=raise_err)
+
+
+def print_tables(nwbfile_path: Path):
+    nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
+    with open("tables.txt", "w") as f:
+        print("=== NWB File ===", file=f)
+        print(sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== Session ===", file=f)
+        print(sgc.Session & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== Subject ===", file=f)
+        print(sgc.Subject(), file=f)
+
+
+def main():
+    nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/H7115-250618.nwb")
+    nwb_copy_file_name = get_nwb_copy_filename(nwbfile_path.name)
+
+    (sgc.Nwbfile & {"nwb_file_name": nwb_copy_file_name}).delete()
+
+    insert_session(nwbfile_path, rollback_on_fail=True, raise_err=True)
+    print_tables(nwbfile_path=nwbfile_path)
+
+
+if __name__ == "__main__":
+    main()
+    print("Done!")

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -48,10 +48,17 @@ def print_tables(nwbfile_path: Path):
         print("=== Subject ===", file=f)
         print(sgc.Subject(), file=f)
 
-        print("=== Camera Device ===", file=f)
-        print(sgc.CameraDevice & {"camera_name": "my_camera_name"}, file=f)
+        print("=== IntervalList ===", file=f)
+        print(sgc.IntervalList & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== Task ===", file=f)
+        print(sgc.Task(), file=f)
+        print("=== Task Epoch ===", file=f)
+        print(sgc.TaskEpoch & {"nwb_file_name": nwb_copy_file_name}, file=f)
+
         print("=== Video File ===", file=f)
-        print(sgc.VideoFile & {"camera_name": "my_camera_name"}, file=f)
+        print(sgc.VideoFile & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== Camera Device ===", file=f)
+        print(sgc.CameraDevice(), file=f)
 
 
 def main():

--- a/tables.txt
+++ b/tables.txt
@@ -7,7 +7,7 @@ H7115-250618_. =BLOB=
 === Session ===
 *nwb_file_name subject_id     institution_na lab_name       session_id     session_descri session_start_ timestamps_ref experiment_des
 +------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+
-H7115-250618_. H7115          University of  Wood/Dudchenko 250618         Cue rotations  2025-06-18 14: 2025-06-18 14: Reorientation 
+H7115-250618_. H7115          University of  Wood/Dudchenko 250618         Cue rotations  2025-06-18 00: 2025-06-18 00: Reorientation 
  (Total: 1)
 
 === Subject ===
@@ -15,4 +15,16 @@ H7115-250618_. H7115          University of  Wood/Dudchenko 250618         Cue r
 +------------+ +------+ +------------+ +----------+ +-----+ +------------+
 H7115          P79D     Fmr1 1915968   KO           M       Rattus norvegi
  (Total: 1)
+
+=== Camera Device ===
+*camera_name   meters_per_pix manufacturer   model     lens     camera_id    
++------------+ +------------+ +------------+ +-------+ +------+ +-----------+
+
+ (Total: 0)
+
+=== Video File ===
+*nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
++------------+ +-------+ +------------+ +------------+ +------------+
+
+ (Total: 0)
 

--- a/tables.txt
+++ b/tables.txt
@@ -43,12 +43,15 @@ H7115-250618_. 3         wake_cue_rot   None           03             cylindrica
 === Video File ===
 *nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
 +------------+ +-------+ +------------+ +------------+ +------------+
-H7115-250618_. 1         0              Video Camera   c3dd2ec9-2a63-
- (Total: 1)
+H7115-250618_. 1         0              Video Camera   3b3aabb8-f9db-
+H7115-250618_. 2         0              Video Camera   01666112-c951-
+H7115-250618_. 3         0              Video Camera   c032fc47-967f-
+ (Total: 3)
 
 === Camera Device ===
-*camera_name   meters_per_pix manufacturer   model     lens         camera_id    
-+------------+ +------------+ +------------+ +-------+ +----------+ +-----------+
-Video Camera   0.0016                        C930e     built-in     0            
- (Total: 1)
+*camera_name   meters_per_pix manufacturer   model        lens         camera_id    
++------------+ +------------+ +------------+ +----------+ +----------+ +-----------+
+my_camera_name 1.0                           my_model     my_lens      1            
+Video Camera   0.0016                        C930e        built-in     0            
+ (Total: 2)
 

--- a/tables.txt
+++ b/tables.txt
@@ -19,9 +19,9 @@ H7115          P79D     Fmr1 1915968   KO           M       Rattus norvegi
 === IntervalList ===
 *nwb_file_name *interval_list valid_time pipeline    
 +------------+ +------------+ +--------+ +----------+
-H7115-250618_. sleep          =BLOB=                 
-H7115-250618_. wake           =BLOB=                 
-H7115-250618_. wake_cue_rot   =BLOB=                 
+H7115-250618_. 01             =BLOB=                 
+H7115-250618_. 02             =BLOB=                 
+H7115-250618_. 03             =BLOB=                 
  (Total: 3)
 
 === Task ===
@@ -33,16 +33,19 @@ wake_cue_rot   The rat was aw None          None
  (Total: 3)
 
 === Task Epoch ===
-*nwb_file_name *epoch    task_name     camera_name    interval_list_ task_environme camera_nam
-+------------+ +-------+ +-----------+ +------------+ +------------+ +------------+ +--------+
-
- (Total: 0)
+*nwb_file_name *epoch    task_name      camera_name    interval_list_ task_environme camera_nam
++------------+ +-------+ +------------+ +------------+ +------------+ +------------+ +--------+
+H7115-250618_. 1         wake           None           01             cylindrical_op =BLOB=    
+H7115-250618_. 2         sleep          None           02             sleep_containe =BLOB=    
+H7115-250618_. 3         wake_cue_rot   None           03             cylindrical_op =BLOB=    
+ (Total: 3)
 
 === Video File ===
 *nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
 +------------+ +-------+ +------------+ +------------+ +------------+
-
- (Total: 0)
+H7115-250618_. 1         0              Video Camera   0f358d8e-cd83-
+H7115-250618_. 2         0              Video Camera   0f358d8e-cd83-
+ (Total: 2)
 
 === Camera Device ===
 *camera_name   meters_per_pix manufacturer   model     lens         camera_id    

--- a/tables.txt
+++ b/tables.txt
@@ -43,9 +43,8 @@ H7115-250618_. 3         wake_cue_rot   None           03             cylindrica
 === Video File ===
 *nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
 +------------+ +-------+ +------------+ +------------+ +------------+
-H7115-250618_. 1         0              Video Camera   0f358d8e-cd83-
-H7115-250618_. 2         0              Video Camera   0f358d8e-cd83-
- (Total: 2)
+H7115-250618_. 1         0              Video Camera   c3dd2ec9-2a63-
+ (Total: 1)
 
 === Camera Device ===
 *camera_name   meters_per_pix manufacturer   model     lens         camera_id    

--- a/tables.txt
+++ b/tables.txt
@@ -1,0 +1,18 @@
+=== NWB File ===
+*nwb_file_name nwb_file_a
++------------+ +--------+
+H7115-250618_. =BLOB=    
+ (Total: 1)
+
+=== Session ===
+*nwb_file_name subject_id     institution_na lab_name       session_id     session_descri session_start_ timestamps_ref experiment_des
++------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+ +------------+
+H7115-250618_. H7115          University of  Wood/Dudchenko 250618         Cue rotations  2025-06-18 14: 2025-06-18 14: Reorientation 
+ (Total: 1)
+
+=== Subject ===
+*subject_id    age      description    genotype     sex     species       
++------------+ +------+ +------------+ +----------+ +-----+ +------------+
+H7115          P79D     Fmr1 1915968   KO           M       Rattus norvegi
+ (Total: 1)
+

--- a/tables.txt
+++ b/tables.txt
@@ -16,9 +16,25 @@ H7115-250618_. H7115          University of  Wood/Dudchenko 250618         Cue r
 H7115          P79D     Fmr1 1915968   KO           M       Rattus norvegi
  (Total: 1)
 
-=== Camera Device ===
-*camera_name   meters_per_pix manufacturer   model     lens     camera_id    
-+------------+ +------------+ +------------+ +-------+ +------+ +-----------+
+=== IntervalList ===
+*nwb_file_name *interval_list valid_time pipeline    
++------------+ +------------+ +--------+ +----------+
+H7115-250618_. sleep          =BLOB=                 
+H7115-250618_. wake           =BLOB=                 
+H7115-250618_. wake_cue_rot   =BLOB=                 
+ (Total: 3)
+
+=== Task ===
+*task_name     task_descripti task_type     task_subtype  
++------------+ +------------+ +-----------+ +------------+
+sleep          The rat was gi None          None          
+wake           The rat was aw None          None          
+wake_cue_rot   The rat was aw None          None          
+ (Total: 3)
+
+=== Task Epoch ===
+*nwb_file_name *epoch    task_name     camera_name    interval_list_ task_environme camera_nam
++------------+ +-------+ +-----------+ +------------+ +------------+ +------------+ +--------+
 
  (Total: 0)
 
@@ -27,4 +43,10 @@ H7115          P79D     Fmr1 1915968   KO           M       Rattus norvegi
 +------------+ +-------+ +------------+ +------------+ +------------+
 
  (Total: 0)
+
+=== Camera Device ===
+*camera_name   meters_per_pix manufacturer   model     lens         camera_id    
++------------+ +------------+ +------------+ +-------+ +----------+ +-----------+
+Video Camera   0.0016                        C930e     built-in     0            
+ (Total: 1)
 

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -341,6 +341,31 @@ def add_epochs(nwbfile, epochs, metadata):
             tags=epoch_tags[str(epoch+1)]
         )
 
+    # Add tasks to NWB file
+    unique_tasks = set(epoch_tags.values())
+    tasks_module = nwbfile.create_processing_module(name="tasks", description="tasks module")
+    tasks_metadata = metadata["task"]
+    for task in unique_tasks:
+        task_metadata = tasks_metadata[task]
+        description = task_metadata["description"]
+        environment = task_metadata["environment"]
+        camera_id = [0]
+        task_epochs = [epoch for epoch, tag in epoch_tags.items() if tag == task]
+        task_table = DynamicTable(name=task, description=description)
+        task_table.add_column(name="task_name", description="Name of the task.")
+        task_table.add_column(name="task_description", description="Description of the task.")
+        task_table.add_column(name="task_environment", description="The environment the animal was in.")
+        task_table.add_column(name="camera_id", description="Camera ID.")
+        task_table.add_column(name="task_epochs", description="Task epochs.")
+        task_table.add_row(
+            task_name=task,
+            task_description=description,
+            task_environment=environment,
+            camera_id=camera_id,
+            task_epochs=task_epochs,
+        )
+        tasks_module.add(task_table)
+
     return nwbfile
 
 

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -335,10 +335,11 @@ def add_epochs(nwbfile, epochs, metadata):
 
     # Add epochs to NWB file
     for epoch in range(epochs.shape[0]):
+        tag = f"{(epoch+1):02d}"  # Spyglass requires 2-digit string epoch numbers
         nwbfile.add_epoch(
             start_time=float(epochs['Start'][epoch]),
             stop_time=float(epochs['End'][epoch]),
-            tags=epoch_tags[str(epoch+1)]
+            tags=[tag],
         )
 
     # Add tasks to NWB file

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -522,3 +522,36 @@ def collect_nwb_metadata(nwbfile):
     pprint.pprint(metadata, width=120, compact=False)
 
     return metadata
+
+from ndx_franklab_novela import CameraDevice
+from pynwb.image import ImageSeries
+def add_video(
+        *,
+        nwbfile: NWBFile,
+        video_file_path: Path,
+        timestamps: np.ndarray,
+        metadata: dict,
+) -> NWBFile:
+    camera_device_metadata = metadata["Video"]["CameraDevice"]
+    camera_device = CameraDevice(
+        name=camera_device_metadata["name"],
+        meters_per_pixel=camera_device_metadata["meters_per_pixel"],
+        model=camera_device_metadata["model"],
+        lens=camera_device_metadata["lens"],
+        camera_name=camera_device_metadata["camera_name"],
+    )
+    nwbfile.add_device(camera_device)
+
+    image_series_metadata = metadata["Video"]["ImageSeries"]
+    image_series = ImageSeries(
+        name=image_series_metadata["name"],
+        description=image_series_metadata["description"],
+        unit=image_series_metadata["unit"],
+        external_file=[str(video_file_path)],
+        format="external",
+        timestamps=timestamps,
+        device=camera_device,
+    )
+    nwbfile.add_acquisition(image_series)
+
+    return nwbfile

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -13,7 +13,8 @@ import numpy as np
 import pandas as pd
 import warnings
 import pynapple as nap
-import cv2
+from ndx_franklab_novela import CameraDevice
+from pynwb.image import ImageSeries
 
 def create_nwb_file(metadata, start_time):
     # get info from folder name
@@ -550,8 +551,7 @@ def collect_nwb_metadata(nwbfile):
 
     return metadata
 
-from ndx_franklab_novela import CameraDevice
-from pynwb.image import ImageSeries
+
 def add_video(
         *,
         nwbfile: NWBFile,
@@ -559,6 +559,8 @@ def add_video(
         timestamp_file_paths: list[Path],
         metadata: dict,
 ) -> NWBFile:
+    print("Adding video to NWB file...")
+
     # Load timestamps from .csv files
     all_timestamps = []
 

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import warnings
 import pynapple as nap
+import cv2
 
 def create_nwb_file(metadata, start_time):
     # get info from folder name
@@ -548,11 +549,21 @@ def add_video(
     )
     nwbfile.add_device(camera_device)
 
+    starting_frames = [0]
+    for video_file_path in video_file_paths[:-1]:
+        cap = cv2.VideoCapture(video_file_path)
+        if not cap.isOpened():
+            raise IOError("Cannot open video file")
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        starting_frame = starting_frames[-1] + frame_count
+        starting_frames.append(starting_frame)
+
     image_series_metadata = metadata["Video"]["ImageSeries"]
     image_series = ImageSeries(
         name=image_series_metadata["name"],
         description=image_series_metadata["description"],
         external_file=video_file_paths,
+        starting_frame=starting_frames,
         format="external",
         timestamps=timestamps,
         rate=rate,

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -529,9 +529,15 @@ def add_video(
         *,
         nwbfile: NWBFile,
         video_file_path: Path,
-        timestamps: np.ndarray,
         metadata: dict,
+        timestamps: np.ndarray | None = None,
+        rate: float | None = None,
 ) -> NWBFile:
+    if timestamps is None and rate is None:
+        raise ValueError("Either timestamps or rate must be provided.")
+    if timestamps is not None and rate is not None:
+        raise ValueError("Only one of timestamps or rate should be provided.")
+    
     camera_device_metadata = metadata["Video"]["CameraDevice"]
     camera_device = CameraDevice(
         name=camera_device_metadata["name"],
@@ -546,10 +552,10 @@ def add_video(
     image_series = ImageSeries(
         name=image_series_metadata["name"],
         description=image_series_metadata["description"],
-        unit=image_series_metadata["unit"],
         external_file=[str(video_file_path)],
         format="external",
         timestamps=timestamps,
+        rate=rate,
         device=camera_device,
     )
     nwbfile.add_acquisition(image_series)

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -528,7 +528,7 @@ from pynwb.image import ImageSeries
 def add_video(
         *,
         nwbfile: NWBFile,
-        video_file_path: Path,
+        video_file_paths: list[Path],
         metadata: dict,
         timestamps: np.ndarray | None = None,
         rate: float | None = None,
@@ -552,7 +552,7 @@ def add_video(
     image_series = ImageSeries(
         name=image_series_metadata["name"],
         description=image_series_metadata["description"],
-        external_file=[str(video_file_path)],
+        external_file=video_file_paths,
         format="external",
         timestamps=timestamps,
         rate=rate,

--- a/woodcode/nwb/io.py
+++ b/woodcode/nwb/io.py
@@ -11,13 +11,13 @@ import pynapple as nap
 import pprint
 
 
-def get_openephys_events(datapath, foldername, time_offset=0, skip_first=0):
+def get_openephys_events(states_path, timestamps_path, time_offset=0, skip_first=0):
 # to do: account for instances when TTL is up at epoch edges
 
     print('Importing events from OpenEphys npy files...')
     # importing events
-    states = np.load(datapath / foldername / 'Analysis' / 'states.npy')
-    timestamps = np.load(datapath / foldername / 'Analysis' / 'timestamps.npy')
+    states = np.load(states_path)
+    timestamps = np.load(timestamps_path)
     events = pd.Series(states, index=timestamps+time_offset)
     events = events.iloc[skip_first:]
 
@@ -100,20 +100,20 @@ import pytz
 from pathlib import Path
 
 
-def get_start_time(datapath, foldername):
+def get_start_time(foldername, metadata_path):
     """
     Retrieves the recording start time from a metadata file or extracts it from the folder name.
 
     Parameters:
-    - datapath (Path): Base directory containing the data.
     - foldername (str): Folder name, used to extract date if the file is missing.
+    - metadata_path (Path): Path to the Metadata.txt file.
 
     Returns:
     - datetime: The localized recording start time.
     """
 
     print('Importing start time from Metadata.txt file...')
-    file_path = datapath / foldername / 'Analysis' / "Metadata.txt"
+    file_path = metadata_path
 
     # Attempt to read from file if it exists
     if file_path.exists():


### PR DESCRIPTION
This PR updates the `add_epochs` function in the existing convert.py module so that the epochs and tasks are compatible with Spyglass insertion. It also adds a new `add_video` function that adds Spyglass-compatible ImageSeries to represent the video.

You can check tables.txt for the outputs of inserting the session into Spyglass, and the example nwb file can be found here: https://drive.google.com/file/d/1RKWtbj63N68ma_4tmTFdY_0UOq_oDW_9/view?usp=drive_link