### PR TITLE
Sorting

### DIFF
--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -71,7 +71,7 @@ def session_to_nwb(
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    
     nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data)
     # nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
-    # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
+    nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
     # nwbfile = nwb.convert.add_events(nwbfile, events)
     metadata["task"] = {
         'wake': {

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -31,10 +31,9 @@ from tqdm import tqdm
 def insert_sorting(nwbfile_path: Path):
     """Insert spike sorting data and unit annotations into SpyGlass database.
 
-    Creates a sorted spikes group containing all units and adds detailed unit
-    annotations including tetrode information, waveform statistics, and unit
-    identifiers. Annotations are categorized as either labels (categorical)
-    or quantifications (numerical) based on their data type.
+    Creates a sorted spikes group containing all units from the imported spike
+    sorting data and adds annotations for each unit. The annotations include
+    sampling rate and mean waveform data extracted from the NWB file.
 
     Parameters
     ----------
@@ -43,9 +42,10 @@ def insert_sorting(nwbfile_path: Path):
 
     Notes
     -----
-    The function creates the following annotations:
-    - Labels: None
-    - Quantifications: sampling_rate, waveform_mean
+    The function creates a group named "all_units" and adds the following
+    annotations for each unit:
+    - sampling_rate: The sampling rate for the unit
+    - waveform_mean: The mean waveform for the unit
     """
     io = NWBHDF5IO(nwbfile_path, "r")
     nwbfile = io.read()

--- a/tables.txt
+++ b/tables.txt
@@ -137,21 +137,35 @@ H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         15ec7688-2101-
 H7115-250618_. 3e23f72c-e980-
  (Total: 1)
 
-=== Unit Annotation ===
-*spikesorting_ *unit_id    *annotation    label     quantification
-+------------+ +---------+ +------------+ +-------+ +------------+
-14e5bcc6-9332- 0           sampling_rate  None      30000.0       
-14e5bcc6-9332- 1           sampling_rate  None      30000.0       
-14e5bcc6-9332- 2           sampling_rate  None      30000.0       
-14e5bcc6-9332- 3           sampling_rate  None      30000.0       
-14e5bcc6-9332- 4           sampling_rate  None      30000.0       
-14e5bcc6-9332- 5           sampling_rate  None      30000.0       
-14e5bcc6-9332- 6           sampling_rate  None      30000.0       
-14e5bcc6-9332- 7           sampling_rate  None      30000.0       
-14e5bcc6-9332- 8           sampling_rate  None      30000.0       
-14e5bcc6-9332- 9           sampling_rate  None      30000.0       
-14e5bcc6-9332- 10          sampling_rate  None      30000.0       
-14e5bcc6-9332- 11          sampling_rate  None      30000.0       
+=== Annotation ===
+*nwb_file_name *id    label      annotation
++------------+ +----+ +--------+ +--------+
+H7115-250618_. 0      =BLOB=     =BLOB=    
+H7115-250618_. 1      =BLOB=     =BLOB=    
+H7115-250618_. 2      =BLOB=     =BLOB=    
+H7115-250618_. 3      =BLOB=     =BLOB=    
+H7115-250618_. 4      =BLOB=     =BLOB=    
+H7115-250618_. 5      =BLOB=     =BLOB=    
+H7115-250618_. 6      =BLOB=     =BLOB=    
+H7115-250618_. 7      =BLOB=     =BLOB=    
+H7115-250618_. 8      =BLOB=     =BLOB=    
+H7115-250618_. 9      =BLOB=     =BLOB=    
+H7115-250618_. 10     =BLOB=     =BLOB=    
+H7115-250618_. 11     =BLOB=     =BLOB=    
    ...
  (Total: 160)
 
+=== Example Annotation (Unit 0) ===
+{'sampling_rate': 30000, 'waveform_mean': array([[ 6.34307766,  5.13430929,  3.45913649, ...,  2.4161489 ,
+        -1.20863974, -0.35912797],
+       [ 9.08244419,  3.15048695,  4.63822079, ...,  0.37520635,
+        -3.95358086, -4.77135754],
+       [ 8.37880993,  5.135674  ,  8.17830753, ..., -2.14873528,
+        -5.50952148, -5.83360195],
+       ...,
+       [ 8.12689114,  6.13766241,  5.8638649 , ...,  2.635535  ,
+        -2.56024933,  4.99939346],
+       [ 7.82126427,  9.05883598,  5.52494812, ...,  2.19659376,
+        -4.69618893,  1.08915639],
+       [ 6.40062189,  8.41902447,  4.88502502, ...,  1.60865331,
+        -6.21712542, -3.83007574]])}

--- a/tables.txt
+++ b/tables.txt
@@ -45,9 +45,9 @@ H7115-250618_. 3         wake_cue_rot   None           03             cylindrica
 === Video File ===
 *nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
 +------------+ +-------+ +------------+ +------------+ +------------+
-H7115-250618_. 1         0              Video Camera   23ad3ff8-07a8-
-H7115-250618_. 2         0              Video Camera   5aad4615-7b55-
-H7115-250618_. 3         0              Video Camera   03f490e4-be0b-
+H7115-250618_. 1         0              Video Camera   d751f528-1770-
+H7115-250618_. 2         0              Video Camera   3bd6b115-a232-
+H7115-250618_. 3         0              Video Camera   cac832ef-2393-
  (Total: 3)
 
 === Camera Device ===
@@ -122,12 +122,36 @@ Cambridge Neur 1              11             1.0            0.0       500.0     
 === Raw ===
 *nwb_file_name interval_list_ raw_object_id  sampling_rate  comments       description   
 +------------+ +------------+ +------------+ +------------+ +------------+ +------------+
-H7115-250618_. raw data valid 143ff94b-92e7- 30000.0        no comments    Acquisition tr
+H7115-250618_. raw data valid b3422883-ed0e- 30000.0        no comments    Acquisition tr
  (Total: 1)
 
 === ImportedLFP ===
 *nwb_file_name *lfp_electrode *interval_list lfp_sampling_r lfp_object_id 
 +------------+ +------------+ +------------+ +------------+ +------------+
-H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         3e518ba1-6dac-
+H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         15ec7688-2101-
  (Total: 1)
+
+=== ImportedSpikeSorting ===
+*nwb_file_name object_id     
++------------+ +------------+
+H7115-250618_. 3e23f72c-e980-
+ (Total: 1)
+
+=== Unit Annotation ===
+*spikesorting_ *unit_id    *annotation    label     quantification
++------------+ +---------+ +------------+ +-------+ +------------+
+14e5bcc6-9332- 0           sampling_rate  None      30000.0       
+14e5bcc6-9332- 1           sampling_rate  None      30000.0       
+14e5bcc6-9332- 2           sampling_rate  None      30000.0       
+14e5bcc6-9332- 3           sampling_rate  None      30000.0       
+14e5bcc6-9332- 4           sampling_rate  None      30000.0       
+14e5bcc6-9332- 5           sampling_rate  None      30000.0       
+14e5bcc6-9332- 6           sampling_rate  None      30000.0       
+14e5bcc6-9332- 7           sampling_rate  None      30000.0       
+14e5bcc6-9332- 8           sampling_rate  None      30000.0       
+14e5bcc6-9332- 9           sampling_rate  None      30000.0       
+14e5bcc6-9332- 10          sampling_rate  None      30000.0       
+14e5bcc6-9332- 11          sampling_rate  None      30000.0       
+   ...
+ (Total: 160)
 


### PR DESCRIPTION
This PR adds Spyglass-compatible Spike Sorting to the conversion by simply enabling the existing `add_units` function and adding an `insert_sorting` function to the spyglass insertion.

I chose to use the ImportedSpikeSorting.Annotations table instead of the UnitAnnotations table because we have some unit properties that are arrays. Specifically, it's the `waveform_mean` property is an array with a snippet of the average spike waveform for each unit across all 32 channels where that unit was recorded. The UnitAnnotations table only supports scalar-valued annotations. 

See example file: https://drive.google.com/file/d/1CkQd7P9iYrJ0IIO8PWjHoWJlDDNkyHEA/view?usp=drive_link