### PR TITLE
Behavior

### DIFF
--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -70,7 +70,7 @@ def session_to_nwb(
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    
     nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data)
-    # nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
+    nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
     # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
     # nwbfile = nwb.convert.add_events(nwbfile, events)
     metadata["task"] = {
@@ -119,8 +119,6 @@ def session_to_nwb(
     nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, timestamp_file_paths=timestamps_file_paths, metadata=metadata)
     nwbfile = nwb.convert.add_lfp(nwbfile=nwbfile, lfp_path=lfp_file_path, xml_data=xml_data, stub_test=stub_test)
     nwbfile = nwb.convert.add_raw_ephys(nwbfile=nwbfile, folder_path=raw_ephys_folder_path, epochs=epochs, xml_data=xml_data, stub_test=stub_test)
-
-    behavior_module = nwbfile.create_processing_module(name="behavior", description="behavior module")
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)

--- a/conversion_scripts/convert_session.py
+++ b/conversion_scripts/convert_session.py
@@ -65,14 +65,12 @@ def session_to_nwb(
     hd = nwb.io.get_matlab_hd(mat_path / 'TrackingProcessed.mat', vbl_name='ang')
     epochs = pd.read_csv(mat_path / 'Epoch_TS.csv', header=None, names=['Start', 'End'])
     spikes, waveforms, shank_id = nwb.io.get_matlab_spikes(mat_path)
-    events = nwb.io.get_openephys_events(mat_path / 'states.npy', mat_path / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
 
     # CONSTRUCT NWB FILE
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)    
     nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data)
     nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
     # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
-    # nwbfile = nwb.convert.add_events(nwbfile, events)
     metadata["task"] = {
         'wake': {
             'description': 'The rat was awake and foraging for scattered cereal in a cylindrical open field. The recording environment consisted of a cylindrical arena of 73 cm diameter, with 54 cm tall walls, painted light blue. A prominent visual cue was positioned at the top of the wall on the north side; this was 31.5 cm wide and 26 cm tall and consisted of two black horizontal stripes with a white stripe between them.',
@@ -119,6 +117,10 @@ def session_to_nwb(
     nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, timestamp_file_paths=timestamps_file_paths, metadata=metadata)
     nwbfile = nwb.convert.add_lfp(nwbfile=nwbfile, lfp_path=lfp_file_path, xml_data=xml_data, stub_test=stub_test)
     nwbfile = nwb.convert.add_raw_ephys(nwbfile=nwbfile, folder_path=raw_ephys_folder_path, epochs=epochs, xml_data=xml_data, stub_test=stub_test)
+
+    # TODO: figure out what these events are
+    # events = nwb.io.get_openephys_events(mat_path / 'states.npy', mat_path / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
+    # nwbfile = nwb.convert.add_events(nwbfile, events)
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)

--- a/spyglass_insertion_scripts/insert_session.py
+++ b/spyglass_insertion_scripts/insert_session.py
@@ -84,6 +84,16 @@ def print_tables(nwbfile_path: Path):
         print("=== ImportedLFP ===", file=f)
         print(sglfp.ImportedLFP & {"nwb_file_name": nwb_copy_file_name}, file=f)
 
+        # Tracking tables
+        print("=== PositionSource ===", file=f)
+        print(sgc.PositionSource & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== PositionSource.SpatialSeries ===", file=f)
+        print(sgc.PositionSource.SpatialSeries & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== RawPosition.PosObject ===", file=f)
+        print(sgc.RawPosition.PosObject & {"nwb_file_name": nwb_copy_file_name}, file=f)
+        print("=== RawPosition ===", file=f)
+        print((sgc.RawPosition & {"nwb_file_name": nwb_copy_file_name}).fetch1_dataframe(), file=f)
+
 
 def main():
     nwbfile_path = Path("/Volumes/T7/CatalystNeuro/Spyglass/raw/H7115-250618.nwb")

--- a/tables.txt
+++ b/tables.txt
@@ -23,8 +23,9 @@ H7115-250618_. 01             =BLOB=
 H7115-250618_. 02             =BLOB=                   
 H7115-250618_. 03             =BLOB=                   
 H7115-250618_. imported lfp 0 =BLOB=     imported_lfp  
+H7115-250618_. pos 0 valid ti =BLOB=     position      
 H7115-250618_. raw data valid =BLOB=                   
- (Total: 5)
+ (Total: 6)
 
 === Task ===
 *task_name     task_descripti task_type     task_subtype  
@@ -45,9 +46,9 @@ H7115-250618_. 3         wake_cue_rot   None           03             cylindrica
 === Video File ===
 *nwb_file_name *epoch    *video_file_nu camera_name    video_file_obj
 +------------+ +-------+ +------------+ +------------+ +------------+
-H7115-250618_. 1         0              Video Camera   23ad3ff8-07a8-
-H7115-250618_. 2         0              Video Camera   5aad4615-7b55-
-H7115-250618_. 3         0              Video Camera   03f490e4-be0b-
+H7115-250618_. 1         0              Video Camera   44d5a073-5456-
+H7115-250618_. 2         0              Video Camera   8acf52d6-e87b-
+H7115-250618_. 3         0              Video Camera   7ce4cf90-d217-
  (Total: 3)
 
 === Camera Device ===
@@ -122,12 +123,12 @@ Cambridge Neur 1              11             1.0            0.0       500.0     
 === Raw ===
 *nwb_file_name interval_list_ raw_object_id  sampling_rate  comments       description   
 +------------+ +------------+ +------------+ +------------+ +------------+ +------------+
-H7115-250618_. raw data valid 143ff94b-92e7- 30000.0        no comments    Acquisition tr
+H7115-250618_. raw data valid 4960ee17-1971- 30000.0        no comments    Acquisition tr
  (Total: 1)
 
 === ImportedLFP ===
 *nwb_file_name *lfp_electrode *interval_list lfp_sampling_r lfp_object_id 
 +------------+ +------------+ +------------+ +------------+ +------------+
-H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         3e518ba1-6dac-
+H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         23e49f47-9305-
  (Total: 1)
 

--- a/tables.txt
+++ b/tables.txt
@@ -132,3 +132,39 @@ H7115-250618_. raw data valid 4960ee17-1971- 30000.0        no comments    Acqui
 H7115-250618_. imported_lfp_0 imported lfp 0 1250.0         23e49f47-9305-
  (Total: 1)
 
+=== PositionSource ===
+*nwb_file_name *interval_list source       import_file_na
++------------+ +------------+ +----------+ +------------+
+H7115-250618_. pos 0 valid ti imported                   
+ (Total: 1)
+
+=== PositionSource.SpatialSeries ===
+*nwb_file_name *interval_list *id    name          
++------------+ +------------+ +----+ +------------+
+H7115-250618_. pos 0 valid ti 0      head-direction
+H7115-250618_. pos 0 valid ti 1      position      
+ (Total: 2)
+
+=== RawPosition.PosObject ===
+*nwb_file_name *interval_list *id    raw_position_o
++------------+ +------------+ +----+ +------------+
+H7115-250618_. pos 0 valid ti 0      0fde528a-2140-
+H7115-250618_. pos 0 valid ti 1      83796f9a-84ba-
+ (Total: 2)
+
+=== RawPosition ===
+              Horizontal angle of the head (yaw)1          x          y
+time                                                                   
+5.855467                                 0.734463  77.552873  37.483203
+5.880467                                 0.733860  77.559722  37.479753
+5.905467                                 0.731943  77.558791  37.476127
+5.930467                                 0.739363  77.519323  37.510633
+5.955467                                 0.734298  77.505247  37.546348
+...                                           ...        ...        ...
+10317.299800                            -2.121394  58.622316  23.538703
+10317.324800                            -2.145793  58.751171  23.618785
+10317.349800                            -2.142109  58.532297  23.520063
+10317.374800                            -2.157710  58.542241  23.588006
+10317.399800                            -2.075986  58.389690  23.438468
+
+[411860 rows x 3 columns]

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -291,20 +291,23 @@ def add_tracking(nwbfile, pos, ang=None):
         unit='centimeters'
     )
     position_obj = Position(spatial_series=spatial_series_obj)
-    behavior_module.add(position_obj)
+    # behavior_module.add(position_obj)
 
     # Add head-direction data only if ang is provided
     if ang is not None:
+        data = ang.values[:, np.newaxis]  # Spyglass requires 2D array for all SpatialSeries
         spatial_series_obj = SpatialSeries(
             name='head-direction',
             description='Horizontal angle of the head (yaw)',
-            data=ang.values,
+            data=data,
             timestamps=ang.index.to_numpy(),
             reference_frame='',
             unit='radians'
         )
-        direction_obj = CompassDirection(spatial_series=spatial_series_obj)
-        behavior_module.add(direction_obj)
+        # direction_obj = CompassDirection(spatial_series=spatial_series_obj)
+        # behavior_module.add(direction_obj)
+        position_obj.add_spatial_series(spatial_series_obj)
+        behavior_module.add(position_obj)
 
     return nwbfile
 


### PR DESCRIPTION
This PR adds Spyglass-compatible tracking behavior to the conversion by updating the existing `add_tracking` function.

Spyglass already natively supports the `Position` object, but not the compass direction. As a workaround, I included the head direction angle as a `SpatialSeries` in the `Position` object. See issue: https://github.com/LorenFrankLab/spyglass/issues/1439

See example file: https://drive.google.com/file/d/1a8o9S40_hsZl86TsuhzXUBLuB3cDy50y/view?usp=sharing