### PR TITLE
Fix Waveforms

### DIFF
--- a/moore_2025/convert_session.py
+++ b/moore_2025/convert_session.py
@@ -393,7 +393,7 @@ def session_to_nwb(
     nwbfile = nwb.convert.create_nwb_file(metadata, start_time)
     nwbfile = nwb.convert.add_probes(nwbfile, metadata, xml_data, nrs_data, probe_info)
     nwbfile = nwb.convert.add_tracking(nwbfile, pos, hd)
-    nwbfile = nwb.convert.add_raw_tracking(nwbfile=nwbfile, file_paths=timestamps_file_paths, all_aligned_timestamps=all_aligned_video_timestamps)
+    nwbfile = nwb.convert.add_raw_tracking(nwbfile=nwbfile, file_paths=timestamps_file_paths, all_aligned_timestamps=all_aligned_video_timestamps, is_adult=is_adult)
     nwbfile = nwb.convert.add_video(nwbfile=nwbfile, video_file_paths=video_file_paths, all_aligned_video_timestamps=all_aligned_video_timestamps, metadata=metadata)
     nwbfile = nwb.convert.add_raw_ephys(nwbfile=nwbfile, folder_path=raw_ephys_folder_path, xml_data=xml_data, stream_name=stream_name, stub_test=stub_test)
     nwbfile = nwb.convert.add_lfp(nwbfile=nwbfile, lfp_path=lfp_file_path, xml_data=xml_data, raw_eseries=nwbfile.acquisition['e-series'], stub_test=stub_test)
@@ -402,11 +402,6 @@ def session_to_nwb(
     epochs = nwb.convert.get_epochs_from_eseries(eseries=nwbfile.acquisition['e-series'])
     nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
     nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id, lfp_eseries, lfp_sampling_rate)  # get shank names from NWB file
-
-    # TODO: figure out what these events are
-    # TODO: don't forget to temporally align the events if and when they get included in the conversion
-    # events = nwb.io.get_openephys_events(mat_path / 'states.npy', mat_path / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
-    # nwbfile = nwb.convert.add_events(nwbfile, events)
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)

--- a/moore_2025/convert_session.py
+++ b/moore_2025/convert_session.py
@@ -421,41 +421,43 @@ def main():
     juvenile_folder_path = dataset_path / "H3000_Juveniles"
     metadata_file_path = Path("/Users/pauladkisson/Documents/CatalystNeuro/DudchenkoConv/woodcode/moore_2025/juvenile_metadata.yaml")
 
-    # # Example Juvenile WT session
-    # jv_wt_folder_path = juvenile_folder_path / "WT"
-    # folder_name = 'H3022-210805'
-    # xml_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
-    # nrs_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
-    # meta_path = dataset_path / 'MooreDataset_Metadata.xlsx'  # path to metadata file
-    # mat_path = jv_wt_folder_path / folder_name / "Processed" / 'Analysis'
-    # sleep_path = jv_wt_folder_path / folder_name / "Processed" / 'Sleep'
-    # video_file_paths = [
-    #     jv_wt_folder_path / folder_name / "Raw" / "BonsaiCaptureALL2021-08-05T17_06_24.avi",
-    # ]
-    # timestamps_file_paths = [
-    #     jv_wt_folder_path / folder_name / "Raw" / "Bonsai testing2021-08-05T17_06_23.csv",
-    # ]
-    # lfp_file_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.lfp')
-    # raw_ephys_folder_path = jv_wt_folder_path / folder_name / "Raw"
-    # save_path = output_folder_path
+    # Example Juvenile WT session
+    jv_wt_folder_path = juvenile_folder_path / "WT"
+    folder_name = 'H3022-210805'
+    raw_xml_path = jv_wt_folder_path / folder_name / "Raw" / "experiment1" / "recording1" / "continuous" / "Rhythm_FPGA-100.0" / "continuous.xml"
+    processed_xml_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
+    nrs_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
+    meta_path = dataset_path / 'MooreDataset_Metadata.xlsx'  # path to metadata file
+    mat_path = jv_wt_folder_path / folder_name / "Processed" / 'Analysis'
+    sleep_path = jv_wt_folder_path / folder_name / "Processed" / 'Sleep'
+    video_file_paths = [
+        jv_wt_folder_path / folder_name / "Raw" / "BonsaiCaptureALL2021-08-05T17_06_24.avi",
+    ]
+    timestamps_file_paths = [
+        jv_wt_folder_path / folder_name / "Raw" / "Bonsai testing2021-08-05T17_06_23.csv",
+    ]
+    lfp_file_path = jv_wt_folder_path / folder_name / "Processed" / (folder_name + '.lfp')
+    raw_ephys_folder_path = jv_wt_folder_path / folder_name / "Raw"
+    save_path = output_folder_path
 
-    # session_to_nwb(
-    #     dataset_path=dataset_path,
-    #     folder_name=folder_name,
-    #     xml_path=xml_path,
-    #     nrs_path=nrs_path,
-    #     meta_path=meta_path,
-    #     mat_path=mat_path,
-    #     sleep_path=sleep_path,
-    #     video_file_paths=video_file_paths,
-    #     timestamps_file_paths=timestamps_file_paths,
-    #     lfp_file_path=lfp_file_path,
-    #     raw_ephys_folder_path=raw_ephys_folder_path,
-    #     save_path=save_path,
-    #     metadata_file_path=metadata_file_path,
-    #     stub_test=stub_test,
-    #     is_adult=False,
-    # )
+    session_to_nwb(
+        dataset_path=dataset_path,
+        folder_name=folder_name,
+        raw_xml_path=raw_xml_path,
+        processed_xml_path=processed_xml_path,
+        nrs_path=nrs_path,
+        meta_path=meta_path,
+        mat_path=mat_path,
+        sleep_path=sleep_path,
+        video_file_paths=video_file_paths,
+        timestamps_file_paths=timestamps_file_paths,
+        lfp_file_path=lfp_file_path,
+        raw_ephys_folder_path=raw_ephys_folder_path,
+        save_path=save_path,
+        metadata_file_path=metadata_file_path,
+        stub_test=stub_test,
+        is_adult=False,
+    )
 
     # Example Juvenile KO session
     jv_ko_folder_path = juvenile_folder_path / "KO"
@@ -494,7 +496,6 @@ def main():
         stub_test=stub_test,
         is_adult=False,
     )
-    return
 
     # Example Adult Sessions
     adult_folder_path = dataset_path / "H4800_Adults"
@@ -504,7 +505,8 @@ def main():
     adult_wt_folder_path = adult_folder_path / "WT"
     folder_name = 'H4813-220728'
     # Note: using the XML from the Raw folder here since the one in Processed is missing one of the channels for shank 2
-    xml_path = adult_wt_folder_path / folder_name / "Raw" / "experiment1" / "recording1" / "continuous" / "Rhythm_FPGA-103.0" / "continuous.xml"
+    processed_xml_path = adult_wt_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
+    raw_xml_path = adult_wt_folder_path / folder_name / "Raw" / "experiment1" / "recording1" / "continuous" / "Rhythm_FPGA-103.0" / "continuous.xml"
     nrs_path = adult_wt_folder_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
     meta_path = dataset_path / 'MooreDataset_Metadata.xlsx'  # path to metadata file
     mat_path = adult_wt_folder_path / folder_name / "Processed" / 'Analysis'
@@ -527,7 +529,8 @@ def main():
     session_to_nwb(
         dataset_path=dataset_path,
         folder_name=folder_name,
-        raw_xml_path=xml_path,
+        raw_xml_path=raw_xml_path,
+        processed_xml_path=processed_xml_path,
         nrs_path=nrs_path,
         meta_path=meta_path,
         mat_path=mat_path,
@@ -545,7 +548,8 @@ def main():
     # Example Adult KO session
     adult_ko_folder_path = adult_folder_path / "KO"
     folder_name = 'H4817-220828'
-    xml_path = adult_ko_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
+    raw_xml_path = adult_ko_folder_path / folder_name / "Raw" / "experiment1" / "recording1" / "continuous" / "Rhythm_FPGA-103.0" / "continuous.xml"
+    processed_xml_path = adult_ko_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
     nrs_path = adult_ko_folder_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
     meta_path = dataset_path / 'MooreDataset_Metadata.xlsx'  # path to metadata file
     mat_path = adult_ko_folder_path / folder_name / "Processed" / 'Analysis'
@@ -568,7 +572,8 @@ def main():
     session_to_nwb(
         dataset_path=dataset_path,
         folder_name=folder_name,
-        raw_xml_path=xml_path,
+        raw_xml_path=raw_xml_path,
+        processed_xml_path=processed_xml_path,
         nrs_path=nrs_path,
         meta_path=meta_path,
         mat_path=mat_path,

--- a/moore_2025/convert_session.py
+++ b/moore_2025/convert_session.py
@@ -548,8 +548,9 @@ def main():
     # Example Adult KO session
     adult_ko_folder_path = adult_folder_path / "KO"
     folder_name = 'H4817-220828'
-    raw_xml_path = adult_ko_folder_path / folder_name / "Raw" / "experiment1" / "recording1" / "continuous" / "Rhythm_FPGA-103.0" / "continuous.xml"
+    # Raw XML for this session is missing one of the channels (channel 38 on shank 1), so using the Processed XML instead
     processed_xml_path = adult_ko_folder_path / folder_name / "Processed" / (folder_name + '.xml')  # path to xml file
+    raw_xml_path = processed_xml_path
     nrs_path = adult_ko_folder_path / folder_name / "Processed" / (folder_name + '.nrs')  # path to xml file
     meta_path = dataset_path / 'MooreDataset_Metadata.xlsx'  # path to metadata file
     mat_path = adult_ko_folder_path / folder_name / "Processed" / 'Analysis'

--- a/moore_2025/convert_session.py
+++ b/moore_2025/convert_session.py
@@ -401,15 +401,12 @@ def session_to_nwb(
     nwbfile = nwb.convert.add_sleep(nwbfile, sleep_path, folder_name, lfp_eseries, lfp_sampling_rate)
     epochs = nwb.convert.get_epochs_from_eseries(eseries=nwbfile.acquisition['e-series'])
     nwbfile = nwb.convert.add_epochs(nwbfile, epochs, metadata)
+    nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id, lfp_eseries, lfp_sampling_rate)  # get shank names from NWB file
 
     # TODO: figure out what these events are
     # TODO: don't forget to temporally align the events if and when they get included in the conversion
     # events = nwb.io.get_openephys_events(mat_path / 'states.npy', mat_path / 'timestamps.npy', time_offset=epochs.at[len(epochs)-1, 'Start'], skip_first=16)  # load LED events
     # nwbfile = nwb.convert.add_events(nwbfile, events)
-
-    # TODO: Figure out how to accommodate waveform_means with different numbers of channels for each shank
-    # TODO: don't forget to temporally align the spike times when they get included in the conversion.
-    nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)

--- a/moore_2025/convert_session.py
+++ b/moore_2025/convert_session.py
@@ -409,7 +409,7 @@ def session_to_nwb(
 
     # TODO: Figure out how to accommodate waveform_means with different numbers of channels for each shank
     # TODO: don't forget to temporally align the spike times when they get included in the conversion.
-    # nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
+    nwbfile = nwb.convert.add_units(nwbfile, xml_data, spikes, waveforms, shank_id)  # get shank names from NWB file
 
     # save NWB file
     nwb.convert.save_nwb_file(nwbfile, save_path, folder_name)

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -126,17 +126,17 @@ def add_events(nwbfile, events, event_name="events"):
 
 
 
-def add_units(nwbfile, xml_data, spikes, waveforms, shank_id, lfp_eseries, lfp_sampling_rate):
+def add_units(nwbfile, raw_xml_data, processed_xml_data, spikes, waveforms, shank_id, lfp_eseries, lfp_sampling_rate):
     print('Adding units to NWB file...')
 
     # Get skipped channels per shank for waveform mean adjustment
     shank_id_to_skipped_channel_indices = {}
     shank_id_to_num_channels = {}
-    for shank_index, spike_group in enumerate(xml_data['spike_groups']):
-        shank_id_to_num_channels[shank_index] = len(spike_group)
-        anatomical_group = xml_data['anatomical_groups'][shank_index]
-        for idx, channel in enumerate(anatomical_group):
-            if channel in xml_data['skipped_channels']:
+    for shank_index, raw_spike_group in enumerate(raw_xml_data['spike_groups']):
+        processed_spike_group = processed_xml_data['spike_groups'][shank_index]
+        shank_id_to_num_channels[shank_index] = len(raw_spike_group)
+        for idx, channel in enumerate(raw_spike_group):
+            if channel not in processed_spike_group:
                 if shank_index not in shank_id_to_skipped_channel_indices:
                     shank_id_to_skipped_channel_indices[shank_index] = []
                 shank_id_to_skipped_channel_indices[shank_index].append(idx)
@@ -167,7 +167,7 @@ def add_units(nwbfile, xml_data, spikes, waveforms, shank_id, lfp_eseries, lfp_s
         nwbfile.add_unit(id=ncell,
                          spike_times=aligned_spike_times,
                          waveform_mean=waveform_mean,
-                         sampling_rate=xml_data['dat_sampling_rate'],
+                         sampling_rate=raw_xml_data['dat_sampling_rate'],
                          electrode_group=nwbfile.electrode_groups[group_name])
     return nwbfile
 

--- a/woodcode/nwb/convert.py
+++ b/woodcode/nwb/convert.py
@@ -366,7 +366,7 @@ def add_tracking(nwbfile, pos, ang=None):
     return nwbfile
 
 
-def add_raw_tracking(nwbfile, file_paths: list[Path], all_aligned_timestamps: list[np.ndarray]):
+def add_raw_tracking(nwbfile, file_paths: list[Path], all_aligned_timestamps: list[np.ndarray], is_adult: bool):
     print('Adding raw tracking to NWB file...')
 
     item1_pos, item_2_pos, full_aligned_timestamps = [], [], []
@@ -378,7 +378,8 @@ def add_raw_tracking(nwbfile, file_paths: list[Path], all_aligned_timestamps: li
         item2_y = tracking_df['Item2.Y'].to_numpy()
         item1_pos.append(np.column_stack((item1_x, item1_y)))
         item_2_pos.append(np.column_stack((item2_x, item2_y)))
-        aligned_timestamps = aligned_timestamps[:-1] # -1 bc video has one extra frame at the end compared to Bonsai tracking data
+        if is_adult:
+            aligned_timestamps = aligned_timestamps[:-1] # -1 bc video has one extra frame at the end compared to Bonsai tracking data
         full_aligned_timestamps.append(aligned_timestamps)
     item1_pos = np.concatenate(item1_pos, axis=0)
     item_2_pos = np.concatenate(item_2_pos, axis=0)


### PR DESCRIPTION
This PR fixes a bug with the spike waveforms where some of the waveform means had different shapes due to skipped channels from the OpenEphys system.

Instead of omitting the skipped channels, the units table now represents them as a column of all NaNs.